### PR TITLE
Added main to block-level tags, removed deprecated pass-by-reference call.

### DIFF
--- a/common.php
+++ b/common.php
@@ -55,7 +55,7 @@ function geturiparam($pathdelimiter, $addhttp) {
          'wrap'            => 200,
          'hide-comments'   => TRUE,
          'new-blocklevel-tags' => implode(' ', array(
-           'header', 'footer', 'article', 'section', 'aside', 'nav', 'hgroup', 'figure',
+           'header', 'footer', 'main', 'article', 'section', 'aside', 'nav', 'hgroup', 'figure',
          )),
          'new-inline-tags' => implode(' ', array(
            'mark', 'time', 'meter', 'progress',

--- a/ics/get-cal.php
+++ b/ics/get-cal.php
@@ -138,7 +138,7 @@ if ((substr($uri, 0,7) == "http://") || (substr($uri, 0,8) == "https://")) {
     if ($logfile == '') {
       // if empty or unspecified, get it from one summary or domain
       // look for the summary so we can name the ics file
-      preg_match_all( '/SUMMARY.*?:(.*)/i', $Str, &$matches);
+      preg_match_all( '/SUMMARY.*?:(.*)/i', $Str, $matches);
       // get the matched line and all matches for our requested parameter
       // if we get more than 1 summary we've got a group of hCalendar events
       // so name the file after the domain.

--- a/vcf/get-contact.php
+++ b/vcf/get-contact.php
@@ -111,7 +111,7 @@ if ((substr($uri, 0,7) == "http://") || (substr($uri, 0,8) == "https://")) {
     if ($logfile == '') {
       // if empty or unspecified, get it from one fn or domain
       // look for the fullname so we can name the vcf
-      preg_match_all( '/FN.*?:(.*)/i', $Str, &$matches);
+      preg_match_all( '/FN.*?:(.*)/i', $Str, $matches);
       // get the matched line and all matches for our requested parameter
       // if we get more than 1 name we've got a group of hCards 
       // so name the file after the domain.


### PR DESCRIPTION
Hi Tantek,

don't know if this project is still alive, but I did some small fixes while playing around with it.
- Added the `main` element to the list of block-level tags
- Fixed an error caused in PHP 5.4+ by using pass-by-reference function call, which is deprecated.
